### PR TITLE
feat: GitHub Actions deploy to blanxlait-ai

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,22 +49,10 @@ jobs:
 
       - name: Patch config.yaml for this deployment
         run: |
-          cd infra-cdk
-          python3 - <<'EOF'
-          import yaml, sys
-
-          with open("config.yaml") as f:
-              config = yaml.safe_load(f)
-
-          config["stack_name_base"] = "${{ github.event.inputs.stack_name_base }}"
-          config["backend"]["pattern"] = "${{ github.event.inputs.pattern }}"
-
-          with open("config.yaml", "w") as f:
-              yaml.dump(config, f, default_flow_style=False, allow_unicode=True)
-
-          print("config.yaml updated:")
-          print(yaml.dump(config))
-          EOF
+          sed -i "s/^stack_name_base:.*/stack_name_base: ${{ github.event.inputs.stack_name_base }}/" infra-cdk/config.yaml
+          sed -i "s/^  pattern:.*$/  pattern: ${{ github.event.inputs.pattern }}/" infra-cdk/config.yaml
+          echo "config.yaml after patching:"
+          cat infra-cdk/config.yaml
 
       - name: CDK bootstrap
         run: cd infra-cdk && npx cdk bootstrap aws://057122451218/us-east-1


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` deploy workflow targeting blanxlait-ai (`057122451218`)
- Uses same two-hop OIDC role-chaining pattern as other blanxlait repos: management account (`982682372189`) → `GitHubDeployRole` in blanxlait-ai
- Parameterized inputs for `stack_name_base` (default: `agentsoar`) and `pattern` (default: `agui-strands-agent`)
- Patches `config.yaml` at deploy time so no committed config changes needed per environment
- Runs `cdk bootstrap` (idempotent) then `cdk deploy --all --concurrency 3`
- Prints the `GitHubPatSecretArn` post-deploy as a reminder to populate the GitHub PAT

## Test plan

- [ ] Merge and trigger manually via Actions → Deploy AgentSOAR → Run workflow
- [ ] Confirm all CDK stacks deploy successfully in blanxlait-ai
- [ ] Populate GitHub PAT via the printed `aws secretsmanager put-secret-value` command
- [ ] Verify agent can create a GitHub issue via the Gateway

🤖 Generated with [Claude Code](https://claude.com/claude-code)