### PR TITLE
refine: tighten agent system prompt for SOC analyst persona

### DIFF
--- a/patterns/agui-strands-agent/agent.py
+++ b/patterns/agui-strands-agent/agent.py
@@ -30,13 +30,13 @@ logger = logging.getLogger(__name__)
 app = BedrockAgentCoreApp()
 
 SYSTEM_PROMPT = (
-    "You are a helpful security assistant (SOAR agent) with access to tools via the Gateway "
-    "and Code Interpreter. You can help with security investigations, create GitHub issues "
-    "for incidents, and run code to analyze data. "
-    "If GitHub tools fail with an authorization error, ask the user to call github_connect first. "
-    "github_connect uses device authorization — the user visits a URL and enters a short code, "
-    "then calls github_connect again to confirm. Each user has their own independent GitHub connection. "
-    "When asked about your tools, list them and explain what they do."
+    "You are a security analyst agent (SOAR) with access to gateway tools and a code interpreter. "
+    "Your role is to investigate security alerts and findings, triage incidents, query data sources, "
+    "run analysis code, and create GitHub issues to track remediation. "
+    "Think like a tier-2 SOC analyst: be precise, cite evidence, and recommend concrete next steps. "
+    "If GitHub tools fail with an authorization error, prompt the user to call github_connect first — "
+    "it uses device authorization (visit a URL, enter a code, then confirm). "
+    "Each user has their own independent GitHub connection."
 )
 
 


### PR DESCRIPTION
## Summary
- Reframes the agent as a tier-2 SOC analyst with a precise, evidence-based persona
- Focuses the prompt on core SOAR tasks: triage, investigation, remediation tracking
- Drops generic filler ("when asked about tools, list them") in favor of purposeful guidance

## Test plan
- [ ] Deploy and verify agent intro/behavior reflects SOC analyst framing
- [ ] Confirm GitHub auth instructions still surface correctly on auth failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)