### PR TITLE
feat: add native iOS SwiftUI client (mobile/ios)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ The out-of-the-box architecture is shown above. The diagram illustrates the auth
 ### Tech Stack
 
 - **Frontend**: React with TypeScript, Vite, Tailwind CSS, and shadcn components - infinitely flexible and ready for coding assistants
+- **iOS app**: Native SwiftUI client (`mobile/ios/`) — same wire format as the web client, AG-UI streaming, Cognito PKCE
 - **Agent Providers**: Multiple agent providers supported (Strands, LangGraph, etc.) running within AgentCore Runtime
 - **Authentication**: AWS Cognito User Pool with OAuth support for easy swapping out Cognito
 - **Infrastructure**: CDK deployment with Amplify Hosting for frontend and AgentCore backend ([Terraform also supported](infra-terraform/README.md))

--- a/blog/04-ios-mobile-app.md
+++ b/blog/04-ios-mobile-app.md
@@ -1,0 +1,225 @@
+# Part 4 — Native iOS Client for AgentSOAR
+
+The web frontend has been the only way to talk to AgentSOAR. That's fine at a
+desk, but a SOAR platform is a thing you reach for when an alert pages you at
+2am — which probably means you're holding a phone, not opening a laptop. This
+post adds a native SwiftUI client that streams from the same AG-UI runtime as
+the web app.
+
+## Goals
+
+1. **Same wire format as the web client.** No bespoke "mobile API" — anything
+   the web app does, the iOS app does by hitting the same Bedrock AgentCore
+   endpoint with a Cognito JWT.
+2. **Cognito sign-in via the system browser.** No embedded WKWebView with
+   stored credentials — `ASWebAuthenticationSession` so federated SSO and
+   biometric password autofill keep working.
+3. **Real-time streaming.** Token-by-token text deltas plus tool-call inline
+   rendering, exactly like the web `ChatInterface`.
+4. **No third-party SDKs.** Foundation, CryptoKit, AuthenticationServices,
+   Security, SwiftUI — everything in the box.
+
+## Layout
+
+The iOS code lives at `mobile/ios/AgentSOAR/`:
+
+```
+mobile/ios/AgentSOAR/
+├── Package.swift                Swift Package: AgentSOARKit + tests
+├── Sources/
+│   ├── AgentSOARKit/            Reusable SDK
+│   │   ├── AgentCore/           Client, AG-UI parser, SSE reader
+│   │   ├── Auth/                Cognito PKCE + Keychain
+│   │   └── Config/              aws-exports.json decoder
+│   └── AgentSOARApp/            SwiftUI app sources
+└── Tests/                       XCTest suites
+```
+
+The SDK is split out so it can be reused — a future macOS menubar app, a
+Shortcuts extension, an Apple Watch complication — without dragging the UI in.
+
+## Wire format
+
+Direct port of `frontend/src/lib/agentcore-client/client.ts`:
+
+```swift
+let endpoint = "https://bedrock-agentcore.\(region).amazonaws.com"
+let url = URL(string: "\(endpoint)/runtimes/\(escapedArn)/invocations?qualifier=DEFAULT")!
+
+var request = URLRequest(url: url)
+request.httpMethod = "POST"
+request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+request.setValue(traceId, forHTTPHeaderField: "X-Amzn-Trace-Id")
+request.setValue(sessionId, forHTTPHeaderField: "X-Amzn-Bedrock-AgentCore-Runtime-Session-Id")
+request.httpBody = try JSONSerialization.data(withJSONObject: [
+    "threadId": sessionId,
+    "runId": UUID().uuidString.lowercased(),
+    "messages": [["id": UUID().uuidString.lowercased(), "role": "user", "content": query]],
+    "state": [:], "tools": [], "context": [], "forwardedProps": [:],
+])
+
+let (bytes, response) = try await URLSession.shared.bytes(for: request)
+```
+
+`URLSession.bytes(for:)` returns an `AsyncBytes` sequence — the same iterator
+the web client gets from `response.body.getReader()`. We split on `\n`, hand
+each line to the AG-UI parser, and yield `StreamEvent`s.
+
+## AG-UI parser
+
+The parser is a 1:1 translation of `parsers/agui.ts`. AG-UI events look like:
+
+```
+data: {"type":"TEXT_MESSAGE_CONTENT","delta":"Hello"}
+data: {"type":"TOOL_CALL_START","toolCallId":"t1","toolCallName":"lookup_finding"}
+data: {"type":"TOOL_CALL_RESULT","toolCallId":"t1","content":"…"}
+data: {"type":"RUN_FINISHED"}
+```
+
+`AGUIParser.parse(line:emit:)` strips the `data: ` prefix, decodes the JSON,
+and emits typed events:
+
+```swift
+public enum StreamEvent: Sendable, Equatable {
+    case text(String)
+    case toolUseStart(toolUseId: String, name: String)
+    case toolUseDelta(toolUseId: String, input: String)
+    case toolResult(toolUseId: String, result: String)
+    case result(stopReason: String)
+    case lifecycle(String)
+}
+```
+
+The XCTest suite covers each event type, malformed JSON, missing fields, and
+a full end-to-end stream.
+
+## Cognito sign-in
+
+OAuth Authorization Code + PKCE through `ASWebAuthenticationSession`:
+
+```swift
+var components = URLComponents(url: discovery.authorizationEndpoint, resolvingAgainstBaseURL: false)!
+components.queryItems = [
+    URLQueryItem(name: "client_id", value: config.clientId),
+    URLQueryItem(name: "response_type", value: "code"),
+    URLQueryItem(name: "scope", value: config.scope),
+    URLQueryItem(name: "redirect_uri", value: config.redirectUri),
+    URLQueryItem(name: "code_challenge", value: pkce.challenge),
+    URLQueryItem(name: "code_challenge_method", value: "S256"),
+    URLQueryItem(name: "state", value: state),
+]
+
+let session = ASWebAuthenticationSession(url: components.url!, callbackURLScheme: "agentsoar") { url, error in
+    // exchange code → access_token, store in Keychain
+}
+session.start()
+```
+
+The redirect URI is a custom scheme (`agentsoar://auth/callback`), registered
+both in `Info.plist` and as an allowed callback on the Cognito User Pool
+client. PKCE comes from `CryptoKit.SHA256` — no external deps.
+
+Tokens go into the iOS Keychain with
+`kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`. Refresh-token rotation is
+automatic — the client checks `expiresAt` before every invoke and refreshes
+silently if needed.
+
+### Why not Amplify iOS?
+
+Amplify drags in a chunk of AWS SDK and an opinionated state model. For an
+app that only needs OIDC + a single REST endpoint, ~400 lines of native
+Swift is smaller, easier to audit, and doesn't fight ARC over the URLSession
+delegate lifecycle.
+
+## Streaming UI
+
+`ChatViewModel` consumes the `AsyncThrowingStream<StreamEvent, Error>` and
+appends to a `@Published [ChatMessage]`. Tool calls are tracked alongside the
+assistant message that triggered them so they render inline:
+
+```swift
+for try await event in stream {
+    switch event {
+    case let .text(content):
+        messages[idx].text.append(content)
+    case let .toolUseStart(id, name):
+        messages[idx].toolCalls.append(.init(id: id, name: name))
+    case let .toolUseDelta(id, input):
+        // accumulate JSON arguments
+    case let .toolResult(id, result):
+        // mark tool complete
+    …
+    }
+}
+```
+
+The view shows a `▍` cursor on the streaming bubble, a wrench icon on each
+tool call with a spinner that flips to a green check when the result lands,
+and `ScrollViewReader` auto-scrolls as new content arrives.
+
+## Configuration
+
+The mobile app loads the same `aws-exports.json` the web app does — minus
+some fields it doesn't need:
+
+```json
+{
+  "agentRuntimeArn": "arn:aws:bedrock-agentcore:us-east-1:429971481640:runtime/…",
+  "awsRegion": "us-east-1",
+  "agentPattern": "agui-strands-agent",
+  "authority": "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_…",
+  "client_id": "…",
+  "redirect_uri": "agentsoar://auth/callback",
+  "response_type": "code",
+  "scope": "email openid profile"
+}
+```
+
+The CDK stack already generates `aws-exports.json` for the web frontend; we
+just bundle a copy into the iOS app target. Eventually we'll add a build
+script that fetches it from the deployed Amplify origin so the mobile bundle
+stays in sync automatically.
+
+## Cognito callback URL
+
+Cognito only allows pre-registered callback URLs. To accept the iOS scheme:
+
+```bash
+aws cognito-idp update-user-pool-client \
+  --user-pool-id us-east-1_xxx \
+  --client-id xxx \
+  --callback-urls "https://app.example.com/" "agentsoar://auth/callback" \
+  --allowed-o-auth-flows code \
+  --allowed-o-auth-scopes openid email profile \
+  --allowed-o-auth-flows-user-pool-client \
+  --profile blanxlait-security
+```
+
+This will go into a CDK property in a follow-up PR — for now it's a one-time
+manual step.
+
+## What's missing
+
+- Push notifications for incoming GuardDuty findings (the
+  [Part 3 integration](03-guardduty-integration.md) is the obvious source).
+- Background refresh so a long-running playbook can finish while the app is
+  backgrounded.
+- A finding-deep-link handler (`agentsoar://findings/{id}`) so a notification
+  can drop you straight into the relevant chat.
+- macOS Catalyst build — most of the work is already done since the SDK has
+  no UIKit dependencies.
+
+## Try it
+
+```bash
+git clone https://github.com/niemesrw/AgentSOAR.git
+cd AgentSOAR/mobile/ios/AgentSOAR
+open Package.swift   # or follow mobile/ios/README.md to scaffold the Xcode app
+swift test
+```
+
+The unit tests run on macOS or Linux without simulators. The full app needs
+Xcode 15 and an iOS 16+ device.
+
+Next up: wiring push notifications into the GuardDuty pipeline so the agent
+can wake your phone.

--- a/mobile/ios/AgentSOAR/Package.swift
+++ b/mobile/ios/AgentSOAR/Package.swift
@@ -1,0 +1,33 @@
+// swift-tools-version:5.9
+// AgentSOARKit — Swift SDK for the AgentSOAR Bedrock AgentCore runtime.
+//
+// Builds:
+//   • AgentSOARKit — embeddable library (auth, streaming, AG-UI parsing)
+//   • AgentSOARKitTests — unit tests for the parser and SSE reader
+
+import PackageDescription
+
+let package = Package(
+    name: "AgentSOARKit",
+    platforms: [
+        .iOS(.v16),
+        .macOS(.v13),
+    ],
+    products: [
+        .library(
+            name: "AgentSOARKit",
+            targets: ["AgentSOARKit"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "AgentSOARKit",
+            path: "Sources/AgentSOARKit"
+        ),
+        .testTarget(
+            name: "AgentSOARKitTests",
+            dependencies: ["AgentSOARKit"],
+            path: "Tests/AgentSOARKitTests"
+        ),
+    ]
+)

--- a/mobile/ios/AgentSOAR/Sources/AgentSOARApp/App/AgentSOARApp.swift
+++ b/mobile/ios/AgentSOAR/Sources/AgentSOARApp/App/AgentSOARApp.swift
@@ -1,0 +1,78 @@
+#if canImport(SwiftUI)
+import SwiftUI
+import AgentSOARKit
+
+@main
+struct AgentSOARApp: App {
+    @StateObject private var session = AppSession()
+
+    var body: some Scene {
+        WindowGroup {
+            RootView().environmentObject(session)
+        }
+    }
+}
+
+@MainActor
+final class AppSession: ObservableObject {
+    @Published var config: AgentCoreConfig?
+    @Published var isAuthenticated: Bool = false
+    @Published var loadError: String?
+
+    private(set) var auth: CognitoAuthClient?
+    private(set) var client: AgentCoreClient?
+
+    init() { Task { await bootstrap() } }
+
+    func bootstrap() async {
+        do {
+            let cfg = try Self.loadConfig()
+            let auth = CognitoAuthClient(config: cfg)
+            self.config = cfg
+            self.auth = auth
+            self.client = AgentCoreClient(config: cfg)
+            self.isAuthenticated = (try await auth.validAccessToken()) != nil
+        } catch {
+            self.loadError = error.localizedDescription
+        }
+    }
+
+    func signOut() {
+        auth?.signOut()
+        isAuthenticated = false
+    }
+
+    private static func loadConfig() throws -> AgentCoreConfig {
+        guard let url = Bundle.main.url(forResource: "aws-exports", withExtension: "json") else {
+            throw NSError(
+                domain: "AgentSOAR", code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "aws-exports.json not bundled. Copy from infra-cdk output."]
+            )
+        }
+        return try AgentCoreConfig.load(from: url)
+    }
+}
+
+struct RootView: View {
+    @EnvironmentObject var session: AppSession
+
+    var body: some View {
+        if let error = session.loadError {
+            VStack(spacing: 12) {
+                Image(systemName: "exclamationmark.triangle.fill").font(.largeTitle)
+                Text("Configuration error").font(.headline)
+                Text(error).font(.caption).foregroundStyle(.secondary).multilineTextAlignment(.center)
+            }
+            .padding()
+        } else if let auth = session.auth, let client = session.client {
+            if session.isAuthenticated {
+                ChatView(client: client, auth: auth, onSignOut: session.signOut)
+            } else {
+                LoginView(auth: auth) { session.isAuthenticated = true }
+            }
+        } else {
+            ProgressView("Loading…")
+        }
+    }
+}
+#endif

--- a/mobile/ios/AgentSOAR/Sources/AgentSOARApp/Chat/ChatMessage.swift
+++ b/mobile/ios/AgentSOAR/Sources/AgentSOARApp/Chat/ChatMessage.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// One bubble in the chat transcript. Tool calls are tracked alongside the
+/// assistant message that triggered them so they render inline.
+public struct ChatMessage: Identifiable, Equatable {
+    public enum Role: String { case user, assistant, system }
+
+    public struct ToolCall: Identifiable, Equatable {
+        public let id: String
+        public var name: String
+        public var args: String
+        public var result: String?
+        public init(id: String, name: String, args: String = "", result: String? = nil) {
+            self.id = id; self.name = name; self.args = args; self.result = result
+        }
+    }
+
+    public let id: UUID
+    public let role: Role
+    public var text: String
+    public var toolCalls: [ToolCall]
+    public var isStreaming: Bool
+
+    public init(
+        id: UUID = UUID(),
+        role: Role,
+        text: String = "",
+        toolCalls: [ToolCall] = [],
+        isStreaming: Bool = false
+    ) {
+        self.id = id
+        self.role = role
+        self.text = text
+        self.toolCalls = toolCalls
+        self.isStreaming = isStreaming
+    }
+}

--- a/mobile/ios/AgentSOAR/Sources/AgentSOARApp/Chat/ChatView.swift
+++ b/mobile/ios/AgentSOAR/Sources/AgentSOARApp/Chat/ChatView.swift
@@ -1,0 +1,133 @@
+#if canImport(SwiftUI)
+import SwiftUI
+import AgentSOARKit
+
+public struct ChatView: View {
+    @StateObject private var vm: ChatViewModel
+    private let onSignOut: () -> Void
+
+    public init(client: AgentCoreClient, auth: CognitoAuthClient, onSignOut: @escaping () -> Void) {
+        _vm = StateObject(wrappedValue: ChatViewModel(client: client, auth: auth))
+        self.onSignOut = onSignOut
+    }
+
+    public var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                transcript
+                composer
+            }
+            .navigationTitle("AgentSOAR")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button(action: vm.resetSession) {
+                        Label("New", systemImage: "square.and.pencil")
+                    }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Sign out", action: onSignOut)
+                }
+            }
+            .alert("Error", isPresented: .constant(vm.error != nil), actions: {
+                Button("OK") { vm.error = nil }
+            }, message: { Text(vm.error ?? "") })
+        }
+    }
+
+    private var transcript: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 12) {
+                    ForEach(vm.messages) { msg in
+                        MessageBubble(message: msg)
+                            .id(msg.id)
+                    }
+                }
+                .padding()
+            }
+            .onChange(of: vm.messages.last?.id) { last in
+                guard let last else { return }
+                withAnimation { proxy.scrollTo(last, anchor: .bottom) }
+            }
+        }
+    }
+
+    private var composer: some View {
+        HStack(alignment: .bottom, spacing: 8) {
+            TextField("Ask the SOAR agent…", text: $vm.draft, axis: .vertical)
+                .textFieldStyle(.roundedBorder)
+                .lineLimit(1...5)
+                .disabled(vm.isLoading)
+            Button {
+                Task { await vm.send() }
+            } label: {
+                Image(systemName: vm.isLoading ? "stop.circle.fill" : "arrow.up.circle.fill")
+                    .font(.system(size: 28))
+            }
+            .disabled(vm.draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || vm.isLoading)
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 8)
+        .background(.bar)
+    }
+}
+
+struct MessageBubble: View {
+    let message: ChatMessage
+
+    var body: some View {
+        VStack(alignment: alignment, spacing: 6) {
+            ForEach(message.toolCalls) { call in
+                ToolCallRow(call: call)
+            }
+            if !message.text.isEmpty || message.isStreaming {
+                Text(message.text + (message.isStreaming ? "▍" : ""))
+                    .padding(.horizontal, 12).padding(.vertical, 8)
+                    .background(message.role == .user ? Color.accentColor.opacity(0.15) : Color(.secondarySystemBackground))
+                    .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: message.role == .user ? .trailing : .leading)
+    }
+
+    private var alignment: HorizontalAlignment {
+        message.role == .user ? .trailing : .leading
+    }
+}
+
+struct ToolCallRow: View {
+    let call: ChatMessage.ToolCall
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 6) {
+                Image(systemName: "wrench.and.screwdriver")
+                    .font(.caption)
+                Text(call.name)
+                    .font(.caption.weight(.semibold))
+                if call.result == nil {
+                    ProgressView().controlSize(.mini)
+                } else {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.caption).foregroundStyle(.green)
+                }
+            }
+            if !call.args.isEmpty {
+                Text(call.args)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+                    .lineLimit(3)
+            }
+            if let result = call.result, !result.isEmpty {
+                Text(result)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+                    .lineLimit(6)
+            }
+        }
+        .padding(8)
+        .background(Color(.tertiarySystemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+    }
+}
+#endif

--- a/mobile/ios/AgentSOAR/Sources/AgentSOARApp/Chat/ChatViewModel.swift
+++ b/mobile/ios/AgentSOAR/Sources/AgentSOARApp/Chat/ChatViewModel.swift
@@ -1,0 +1,86 @@
+import Foundation
+import AgentSOARKit
+
+@MainActor
+public final class ChatViewModel: ObservableObject {
+    @Published public private(set) var messages: [ChatMessage] = []
+    @Published public private(set) var isLoading: Bool = false
+    @Published public var draft: String = ""
+    @Published public var error: String?
+
+    private let client: AgentCoreClient
+    private let auth: CognitoAuthClient
+    private var sessionId: String
+
+    public init(client: AgentCoreClient, auth: CognitoAuthClient) {
+        self.client = client
+        self.auth = auth
+        self.sessionId = client.generateSessionId()
+    }
+
+    public func resetSession() {
+        sessionId = client.generateSessionId()
+        messages.removeAll()
+    }
+
+    public func send() async {
+        let text = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty, !isLoading else { return }
+        draft = ""
+        error = nil
+
+        messages.append(ChatMessage(role: .user, text: text))
+        var assistant = ChatMessage(role: .assistant, isStreaming: true)
+        messages.append(assistant)
+        let assistantId = assistant.id
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            guard let token = try await auth.validAccessToken() else {
+                error = "Sign in required."
+                markFinished(id: assistantId)
+                return
+            }
+
+            let stream = try await client.invoke(
+                query: text,
+                sessionId: sessionId,
+                accessToken: token
+            )
+
+            for try await event in stream {
+                apply(event: event, to: assistantId, snapshot: &assistant)
+            }
+        } catch {
+            self.error = error.localizedDescription
+        }
+        markFinished(id: assistantId)
+    }
+
+    private func apply(event: StreamEvent, to id: UUID, snapshot: inout ChatMessage) {
+        guard let idx = messages.firstIndex(where: { $0.id == id }) else { return }
+        switch event {
+        case let .text(content):
+            messages[idx].text.append(content)
+        case let .toolUseStart(toolUseId, name):
+            messages[idx].toolCalls.append(.init(id: toolUseId, name: name))
+        case let .toolUseDelta(toolUseId, input):
+            if let i = messages[idx].toolCalls.firstIndex(where: { $0.id == toolUseId }) {
+                messages[idx].toolCalls[i].args.append(input)
+            }
+        case let .toolResult(toolUseId, result):
+            if let i = messages[idx].toolCalls.firstIndex(where: { $0.id == toolUseId }) {
+                messages[idx].toolCalls[i].result = result
+            }
+        case .result, .lifecycle:
+            break
+        }
+    }
+
+    private func markFinished(id: UUID) {
+        if let idx = messages.firstIndex(where: { $0.id == id }) {
+            messages[idx].isStreaming = false
+        }
+    }
+}

--- a/mobile/ios/AgentSOAR/Sources/AgentSOARApp/Login/LoginView.swift
+++ b/mobile/ios/AgentSOAR/Sources/AgentSOARApp/Login/LoginView.swift
@@ -1,0 +1,79 @@
+#if canImport(SwiftUI) && canImport(AuthenticationServices) && canImport(UIKit)
+import SwiftUI
+import UIKit
+import AuthenticationServices
+import AgentSOARKit
+
+public struct LoginView: View {
+    @State private var isWorking = false
+    @State private var error: String?
+    private let auth: CognitoAuthClient
+    private let onSignedIn: () -> Void
+
+    public init(auth: CognitoAuthClient, onSignedIn: @escaping () -> Void) {
+        self.auth = auth
+        self.onSignedIn = onSignedIn
+    }
+
+    public var body: some View {
+        VStack(spacing: 24) {
+            Spacer()
+            Image(systemName: "shield.lefthalf.filled.badge.checkmark")
+                .font(.system(size: 64, weight: .light))
+                .foregroundStyle(.tint)
+            Text("AgentSOAR")
+                .font(.largeTitle.weight(.semibold))
+            Text("Agentic SOAR on Bedrock AgentCore")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Button {
+                Task { await signIn() }
+            } label: {
+                HStack {
+                    if isWorking { ProgressView().controlSize(.small) }
+                    Text(isWorking ? "Signing in…" : "Sign in")
+                        .font(.headline)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(isWorking)
+            if let error {
+                Text(error).font(.caption).foregroundStyle(.red).multilineTextAlignment(.center)
+            }
+            Spacer().frame(height: 40)
+        }
+        .padding(32)
+    }
+
+    @MainActor
+    private func signIn() async {
+        isWorking = true
+        defer { isWorking = false }
+        error = nil
+        do {
+            guard let anchor = ASPresentationAnchor.firstKeyWindow else {
+                error = "No window available."
+                return
+            }
+            _ = try await auth.signIn(presentationAnchor: anchor)
+            onSignedIn()
+        } catch let AuthError.userCancelled {
+            // silent — user dismissed the sheet
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+}
+
+private extension ASPresentationAnchor {
+    static var firstKeyWindow: ASPresentationAnchor? {
+        UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+            .first(where: { $0.isKeyWindow })
+    }
+}
+#endif

--- a/mobile/ios/AgentSOAR/Sources/AgentSOARApp/Resources/Info.plist
+++ b/mobile/ios/AgentSOAR/Sources/AgentSOARApp/Resources/Info.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDisplayName</key>
+    <string>AgentSOAR</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.agentsoar.ios</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
+    <key>UILaunchScreen</key>
+    <dict/>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+    </array>
+    <key>UISupportedInterfaceOrientations~ipad</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationPortraitUpsideDown</string>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleURLName</key>
+            <string>com.agentsoar.ios.auth</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>agentsoar</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/mobile/ios/AgentSOAR/Sources/AgentSOARApp/Resources/aws-exports.example.json
+++ b/mobile/ios/AgentSOAR/Sources/AgentSOARApp/Resources/aws-exports.example.json
@@ -1,0 +1,11 @@
+{
+  "agentRuntimeArn": "arn:aws:bedrock-agentcore:us-east-1:429971481640:runtime/REPLACE_ME",
+  "awsRegion": "us-east-1",
+  "agentPattern": "agui-strands-agent",
+
+  "authority": "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_REPLACE_ME",
+  "client_id": "REPLACE_ME",
+  "redirect_uri": "agentsoar://auth/callback",
+  "response_type": "code",
+  "scope": "email openid profile"
+}

--- a/mobile/ios/AgentSOAR/Sources/AgentSOARKit/AgentCore/AGUIParser.swift
+++ b/mobile/ios/AgentSOAR/Sources/AgentSOARKit/AgentCore/AGUIParser.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// Parses AG-UI SSE events from `agui-strands-agent` and friends.
+///
+/// AG-UI events arrive as `data: <JSON>` where each JSON object has a `type` field.
+/// Direct port of `frontend/src/lib/agentcore-client/parsers/agui.ts`.
+public struct AGUIParser: ChunkParser {
+    public init() {}
+
+    public func parse(line: String, emit: (StreamEvent) -> Void) {
+        guard line.hasPrefix("data: ") else { return }
+
+        let payload = line.dropFirst(6).trimmingCharacters(in: .whitespaces)
+        guard !payload.isEmpty,
+              let data = payload.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let eventType = json["type"] as? String
+        else { return }
+
+        switch eventType {
+        case "TEXT_MESSAGE_CONTENT":
+            emit(.text((json["delta"] as? String) ?? ""))
+
+        case "TOOL_CALL_START":
+            emit(.toolUseStart(
+                toolUseId: (json["toolCallId"] as? String) ?? "",
+                name: (json["toolCallName"] as? String) ?? ""
+            ))
+
+        case "TOOL_CALL_ARGS":
+            emit(.toolUseDelta(
+                toolUseId: (json["toolCallId"] as? String) ?? "",
+                input: (json["delta"] as? String) ?? ""
+            ))
+
+        case "TOOL_CALL_RESULT":
+            emit(.toolResult(
+                toolUseId: (json["toolCallId"] as? String) ?? "",
+                result: (json["content"] as? String) ?? ""
+            ))
+
+        case "RUN_FINISHED":
+            emit(.result(stopReason: "end_turn"))
+            emit(.lifecycle("run_finished"))
+
+        case "RUN_STARTED":
+            emit(.lifecycle("run_started"))
+
+        case "TEXT_MESSAGE_START":
+            emit(.lifecycle("message_start"))
+
+        case "TEXT_MESSAGE_END":
+            emit(.lifecycle("message_end"))
+
+        case "STATE_SNAPSHOT", "TOOL_CALL_END":
+            // Informational — no-op
+            break
+
+        default:
+            break
+        }
+    }
+}
+
+/// Resolves a parser from a pattern prefix. Currently only AG-UI is wired up
+/// for the mobile client (matching the active deployment); add other parsers
+/// as needed.
+public enum ParserResolver {
+    public static func parser(for pattern: String) -> ChunkParser {
+        if pattern.hasPrefix("agui-") {
+            return AGUIParser()
+        }
+        // Default to AG-UI; extend with strands/langgraph/claude parsers as the
+        // backend exposes them on mobile.
+        return AGUIParser()
+    }
+}

--- a/mobile/ios/AgentSOAR/Sources/AgentSOARKit/AgentCore/AgentCoreClient.swift
+++ b/mobile/ios/AgentSOAR/Sources/AgentSOARKit/AgentCore/AgentCoreClient.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+public enum AgentCoreError: Error, LocalizedError {
+    case missingAccessToken
+    case missingRuntimeArn
+    case http(status: Int, body: String)
+    case invalidResponse
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingAccessToken: return "No valid access token found."
+        case .missingRuntimeArn: return "Agent Runtime ARN not configured."
+        case let .http(status, body): return "HTTP \(status): \(body)"
+        case .invalidResponse: return "Invalid response from AgentCore Runtime."
+        }
+    }
+}
+
+/// Thin Swift port of `AgentCoreClient` from
+/// `frontend/src/lib/agentcore-client/client.ts`.
+///
+/// Builds the AG-UI request payload, opens a streamed POST to
+/// `bedrock-agentcore.{region}.amazonaws.com`, and yields parsed events.
+public final class AgentCoreClient: Sendable {
+    private let runtimeArn: String
+    private let region: String
+    private let pattern: String
+    private let parser: ChunkParser
+    private let session: URLSession
+
+    public init(config: AgentCoreConfig, session: URLSession = .shared) {
+        self.runtimeArn = config.agentRuntimeArn
+        self.region = config.awsRegion
+        self.pattern = config.agentPattern
+        self.parser = ParserResolver.parser(for: config.agentPattern)
+        self.session = session
+    }
+
+    public func generateSessionId() -> String {
+        UUID().uuidString.lowercased()
+    }
+
+    /// Streams events for a single user turn.
+    ///
+    /// User identity is extracted server-side from the validated JWT token,
+    /// not sent in the payload body — this prevents impersonation via prompt
+    /// injection (see `client.ts` for the same comment).
+    public func invoke(
+        query: String,
+        sessionId: String,
+        accessToken: String
+    ) async throws -> AsyncThrowingStream<StreamEvent, Error> {
+        guard !accessToken.isEmpty else { throw AgentCoreError.missingAccessToken }
+        guard !runtimeArn.isEmpty else { throw AgentCoreError.missingRuntimeArn }
+
+        let endpoint = "https://bedrock-agentcore.\(region).amazonaws.com"
+        let escapedArn = runtimeArn.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed.subtracting(CharacterSet(charactersIn: "/:"))) ?? runtimeArn
+        guard let url = URL(string: "\(endpoint)/runtimes/\(escapedArn)/invocations?qualifier=DEFAULT") else {
+            throw AgentCoreError.invalidResponse
+        }
+
+        let traceId = "1-\(String(Int(Date().timeIntervalSince1970), radix: 16))-\(UUID().uuidString.lowercased())"
+
+        let body: [String: Any] = pattern.hasPrefix("agui-")
+            ? [
+                "threadId": sessionId,
+                "runId": UUID().uuidString.lowercased(),
+                "messages": [[
+                    "id": UUID().uuidString.lowercased(),
+                    "role": "user",
+                    "content": query,
+                ]],
+                "state": [String: Any](),
+                "tools": [Any](),
+                "context": [Any](),
+                "forwardedProps": [String: Any](),
+            ]
+            : [
+                "prompt": query,
+                "runtimeSessionId": sessionId,
+            ]
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue(traceId, forHTTPHeaderField: "X-Amzn-Trace-Id")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(sessionId, forHTTPHeaderField: "X-Amzn-Bedrock-AgentCore-Runtime-Session-Id")
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (bytes, response) = try await session.bytes(for: request)
+        guard let http = response as? HTTPURLResponse else { throw AgentCoreError.invalidResponse }
+
+        guard (200..<300).contains(http.statusCode) else {
+            var bodyText = ""
+            for try await byte in bytes {
+                bodyText.append(Character(UnicodeScalar(byte)))
+            }
+            throw AgentCoreError.http(status: http.statusCode, body: bodyText)
+        }
+
+        return SSEStream.read(bytes: bytes, parser: parser)
+    }
+}

--- a/mobile/ios/AgentSOAR/Sources/AgentSOARKit/AgentCore/SSEStream.swift
+++ b/mobile/ios/AgentSOAR/Sources/AgentSOARKit/AgentCore/SSEStream.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Reads a Server-Sent-Events stream from `URLSession.bytes(for:)`, splitting
+/// on `\n` and feeding each non-empty line through a `ChunkParser`.
+///
+/// AgentCore Runtime streams AG-UI events as `data: <JSON>\n\n`. We treat
+/// every newline-delimited fragment as a candidate line for the parser, which
+/// handles the `data: ` prefix itself.
+public enum SSEStream {
+    public static func read(
+        bytes: URLSession.AsyncBytes,
+        parser: ChunkParser
+    ) -> AsyncThrowingStream<StreamEvent, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    var buffer = ""
+                    for try await byte in bytes {
+                        let scalar = UnicodeScalar(byte)
+                        let char = Character(scalar)
+                        if char == "\n" {
+                            let line = buffer
+                            buffer = ""
+                            guard !line.trimmingCharacters(in: .whitespaces).isEmpty else { continue }
+                            parser.parse(line: line) { event in
+                                continuation.yield(event)
+                            }
+                        } else {
+                            buffer.append(char)
+                        }
+                    }
+                    if !buffer.trimmingCharacters(in: .whitespaces).isEmpty {
+                        parser.parse(line: buffer) { event in
+                            continuation.yield(event)
+                        }
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    /// Variant for tests / non-URLSession sources: parse a raw String body.
+    public static func read(
+        body: String,
+        parser: ChunkParser
+    ) -> [StreamEvent] {
+        var out: [StreamEvent] = []
+        for line in body.split(separator: "\n", omittingEmptySubsequences: false) {
+            let trimmed = String(line).trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty else { continue }
+            parser.parse(line: String(line)) { event in out.append(event) }
+        }
+        return out
+    }
+}

--- a/mobile/ios/AgentSOAR/Sources/AgentSOARKit/AgentCore/StreamEvent.swift
+++ b/mobile/ios/AgentSOAR/Sources/AgentSOARKit/AgentCore/StreamEvent.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Parser-emitted events. Mirrors the `StreamEvent` union in
+/// `frontend/src/lib/agentcore-client/types.ts` so any pattern parser
+/// can be adapted to the same downstream UI.
+public enum StreamEvent: Sendable, Equatable {
+    case text(String)
+    case toolUseStart(toolUseId: String, name: String)
+    case toolUseDelta(toolUseId: String, input: String)
+    case toolResult(toolUseId: String, result: String)
+    case result(stopReason: String)
+    case lifecycle(String)
+}
+
+/// Parses one SSE line into zero or more `StreamEvent`s.
+public protocol ChunkParser: Sendable {
+    func parse(line: String, emit: (StreamEvent) -> Void)
+}

--- a/mobile/ios/AgentSOAR/Sources/AgentSOARKit/Auth/CognitoAuthClient.swift
+++ b/mobile/ios/AgentSOAR/Sources/AgentSOARKit/Auth/CognitoAuthClient.swift
@@ -1,0 +1,244 @@
+#if canImport(AuthenticationServices)
+import AuthenticationServices
+#endif
+import Foundation
+
+/// OIDC discovery document — the subset we care about.
+private struct OIDCDiscovery: Decodable {
+    let authorizationEndpoint: URL
+    let tokenEndpoint: URL
+    let endSessionEndpoint: URL?
+
+    enum CodingKeys: String, CodingKey {
+        case authorizationEndpoint = "authorization_endpoint"
+        case tokenEndpoint = "token_endpoint"
+        case endSessionEndpoint = "end_session_endpoint"
+    }
+}
+
+private struct TokenResponse: Decodable {
+    let accessToken: String
+    let idToken: String?
+    let refreshToken: String?
+    let expiresIn: Int
+
+    enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case idToken = "id_token"
+        case refreshToken = "refresh_token"
+        case expiresIn = "expires_in"
+    }
+}
+
+public enum AuthError: Error, LocalizedError {
+    case userCancelled
+    case missingCode
+    case discoveryFailed
+    case tokenExchangeFailed(String)
+    case notAvailable
+
+    public var errorDescription: String? {
+        switch self {
+        case .userCancelled: return "Sign-in cancelled."
+        case .missingCode: return "No authorization code returned by Cognito."
+        case .discoveryFailed: return "Failed to load OIDC discovery document."
+        case let .tokenExchangeFailed(detail): return "Token exchange failed: \(detail)"
+        case .notAvailable: return "Web auth is unavailable on this platform."
+        }
+    }
+}
+
+/// OAuth Authorization Code + PKCE flow against the Cognito User Pool.
+///
+/// On iOS, we drive `ASWebAuthenticationSession` so the system Safari
+/// view chrome handles the federated login (including SSO). Tokens are
+/// persisted in the Keychain via `KeychainTokenStore`.
+public final class CognitoAuthClient: NSObject {
+    private let config: AgentCoreConfig
+    private let store: KeychainTokenStore
+    private let session: URLSession
+
+    public init(
+        config: AgentCoreConfig,
+        store: KeychainTokenStore = KeychainTokenStore(),
+        session: URLSession = .shared
+    ) {
+        self.config = config
+        self.store = store
+        self.session = session
+    }
+
+    public var currentTokens: KeychainTokenStore.Tokens? { store.load() }
+
+    public func signOut() { store.clear() }
+
+    /// Returns a non-expired access token, refreshing if needed.
+    public func validAccessToken() async throws -> String? {
+        guard let tokens = store.load() else { return nil }
+        if tokens.expiresAt > Date().addingTimeInterval(30) {
+            return tokens.accessToken
+        }
+        guard let refresh = tokens.refreshToken else { return nil }
+        let discovery = try await discoverEndpoints()
+        let refreshed = try await refresh(token: refresh, tokenEndpoint: discovery.tokenEndpoint)
+        return refreshed.accessToken
+    }
+
+    #if canImport(AuthenticationServices)
+    /// Drives the full OAuth flow. Must be called from the main actor; the
+    /// presentation context provider keeps a reference to a host window for
+    /// `ASWebAuthenticationSession`.
+    @MainActor
+    public func signIn(presentationAnchor: ASPresentationAnchor) async throws -> KeychainTokenStore.Tokens {
+        let discovery = try await discoverEndpoints()
+        let pkce = PKCE.generate()
+        let state = UUID().uuidString
+
+        var components = URLComponents(url: discovery.authorizationEndpoint, resolvingAgainstBaseURL: false)!
+        components.queryItems = [
+            URLQueryItem(name: "client_id", value: config.clientId),
+            URLQueryItem(name: "response_type", value: config.responseType),
+            URLQueryItem(name: "scope", value: config.scope),
+            URLQueryItem(name: "redirect_uri", value: config.redirectUri),
+            URLQueryItem(name: "code_challenge", value: pkce.challenge),
+            URLQueryItem(name: "code_challenge_method", value: pkce.method),
+            URLQueryItem(name: "state", value: state),
+        ]
+        guard let authURL = components.url else { throw AuthError.discoveryFailed }
+
+        let callbackScheme = URL(string: config.redirectUri)?.scheme
+
+        let callbackURL: URL = try await withCheckedThrowingContinuation { cont in
+            let session = ASWebAuthenticationSession(
+                url: authURL,
+                callbackURLScheme: callbackScheme
+            ) { url, error in
+                if let error {
+                    if (error as NSError).code == ASWebAuthenticationSessionError.canceledLogin.rawValue {
+                        cont.resume(throwing: AuthError.userCancelled)
+                    } else {
+                        cont.resume(throwing: error)
+                    }
+                    return
+                }
+                guard let url else { cont.resume(throwing: AuthError.missingCode); return }
+                cont.resume(returning: url)
+            }
+            session.presentationContextProvider = AnchorProvider(anchor: presentationAnchor)
+            session.prefersEphemeralWebBrowserSession = false
+            session.start()
+        }
+
+        guard let code = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false)?
+                .queryItems?.first(where: { $0.name == "code" })?.value
+        else { throw AuthError.missingCode }
+
+        return try await exchangeCode(
+            code: code,
+            verifier: pkce.verifier,
+            tokenEndpoint: discovery.tokenEndpoint
+        )
+    }
+    #else
+    public func signIn(presentationAnchor: Any) async throws -> KeychainTokenStore.Tokens {
+        throw AuthError.notAvailable
+    }
+    #endif
+
+    // MARK: - HTTP
+
+    private func discoverEndpoints() async throws -> OIDCDiscovery {
+        // Cognito User Pool authorities serve OIDC discovery at
+        // `{authority}/.well-known/openid-configuration`.
+        let discoveryURL = URL(string: "\(config.authority)/.well-known/openid-configuration")!
+        let (data, response) = try await session.data(from: discoveryURL)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            throw AuthError.discoveryFailed
+        }
+        return try JSONDecoder().decode(OIDCDiscovery.self, from: data)
+    }
+
+    private func exchangeCode(
+        code: String,
+        verifier: String,
+        tokenEndpoint: URL
+    ) async throws -> KeychainTokenStore.Tokens {
+        var request = URLRequest(url: tokenEndpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+
+        let form: [String: String] = [
+            "grant_type": "authorization_code",
+            "client_id": config.clientId,
+            "code": code,
+            "redirect_uri": config.redirectUri,
+            "code_verifier": verifier,
+        ]
+        request.httpBody = form.formURLEncoded()
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            let body = String(data: data, encoding: .utf8) ?? ""
+            throw AuthError.tokenExchangeFailed(body)
+        }
+        let decoded = try JSONDecoder().decode(TokenResponse.self, from: data)
+        let tokens = KeychainTokenStore.Tokens(
+            accessToken: decoded.accessToken,
+            idToken: decoded.idToken,
+            refreshToken: decoded.refreshToken,
+            expiresAt: Date().addingTimeInterval(TimeInterval(decoded.expiresIn))
+        )
+        try store.save(tokens)
+        return tokens
+    }
+
+    private func refresh(token refreshToken: String, tokenEndpoint: URL) async throws -> KeychainTokenStore.Tokens {
+        var request = URLRequest(url: tokenEndpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+
+        let form: [String: String] = [
+            "grant_type": "refresh_token",
+            "client_id": config.clientId,
+            "refresh_token": refreshToken,
+        ]
+        request.httpBody = form.formURLEncoded()
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            let body = String(data: data, encoding: .utf8) ?? ""
+            throw AuthError.tokenExchangeFailed(body)
+        }
+        let decoded = try JSONDecoder().decode(TokenResponse.self, from: data)
+        // Cognito refresh responses don't always include a new refresh_token;
+        // keep the existing one if absent.
+        let tokens = KeychainTokenStore.Tokens(
+            accessToken: decoded.accessToken,
+            idToken: decoded.idToken,
+            refreshToken: decoded.refreshToken ?? refreshToken,
+            expiresAt: Date().addingTimeInterval(TimeInterval(decoded.expiresIn))
+        )
+        try store.save(tokens)
+        return tokens
+    }
+}
+
+#if canImport(AuthenticationServices)
+private final class AnchorProvider: NSObject, ASWebAuthenticationPresentationContextProviding {
+    private let anchor: ASPresentationAnchor
+    init(anchor: ASPresentationAnchor) { self.anchor = anchor }
+    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        anchor
+    }
+}
+#endif
+
+private extension Dictionary where Key == String, Value == String {
+    func formURLEncoded() -> Data {
+        let allowed = CharacterSet.urlQueryAllowed.subtracting(CharacterSet(charactersIn: "&+="))
+        let body = self
+            .map { "\($0.key)=\($0.value.addingPercentEncoding(withAllowedCharacters: allowed) ?? "")" }
+            .joined(separator: "&")
+        return Data(body.utf8)
+    }
+}

--- a/mobile/ios/AgentSOAR/Sources/AgentSOARKit/Auth/PKCE.swift
+++ b/mobile/ios/AgentSOAR/Sources/AgentSOARKit/Auth/PKCE.swift
@@ -1,0 +1,38 @@
+import CryptoKit
+import Foundation
+
+/// Generates PKCE code verifier / challenge pairs per RFC 7636.
+public enum PKCE {
+    public struct Pair: Sendable, Equatable {
+        public let verifier: String
+        public let challenge: String
+        public let method: String = "S256"
+    }
+
+    public static func generate() -> Pair {
+        let verifier = randomURLSafeString(byteCount: 32)
+        let challenge = sha256Base64URL(verifier)
+        return Pair(verifier: verifier, challenge: challenge)
+    }
+
+    private static func randomURLSafeString(byteCount: Int) -> String {
+        var bytes = [UInt8](repeating: 0, count: byteCount)
+        _ = SecRandomCopyBytes(kSecRandomDefault, byteCount, &bytes)
+        return Data(bytes).base64URLEncodedString()
+    }
+
+    private static func sha256Base64URL(_ value: String) -> String {
+        let digest = SHA256.hash(data: Data(value.utf8))
+        return Data(digest).base64URLEncodedString()
+    }
+}
+
+extension Data {
+    /// Base64URL encoding (RFC 4648 §5) — `+` → `-`, `/` → `_`, no padding.
+    public func base64URLEncodedString() -> String {
+        base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}

--- a/mobile/ios/AgentSOAR/Sources/AgentSOARKit/Auth/TokenStore.swift
+++ b/mobile/ios/AgentSOAR/Sources/AgentSOARKit/Auth/TokenStore.swift
@@ -1,0 +1,70 @@
+import Foundation
+import Security
+
+/// Stores tokens in the iOS Keychain. Access tokens never touch UserDefaults
+/// or disk — they live behind the keychain's data-protection class until the
+/// device is unlocked at least once.
+public final class KeychainTokenStore: @unchecked Sendable {
+    public struct Tokens: Codable, Sendable, Equatable {
+        public let accessToken: String
+        public let idToken: String?
+        public let refreshToken: String?
+        public let expiresAt: Date
+
+        public init(accessToken: String, idToken: String?, refreshToken: String?, expiresAt: Date) {
+            self.accessToken = accessToken
+            self.idToken = idToken
+            self.refreshToken = refreshToken
+            self.expiresAt = expiresAt
+        }
+    }
+
+    private let service: String
+    private let account: String
+
+    public init(service: String = "com.agentsoar.tokens", account: String = "default") {
+        self.service = service
+        self.account = account
+    }
+
+    public func save(_ tokens: Tokens) throws {
+        let data = try JSONEncoder().encode(tokens)
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        SecItemDelete(query as CFDictionary)
+
+        var attrs = query
+        attrs[kSecValueData as String] = data
+        attrs[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        let status = SecItemAdd(attrs as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            throw NSError(domain: NSOSStatusErrorDomain, code: Int(status))
+        }
+    }
+
+    public func load() -> Tokens? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess, let data = result as? Data else { return nil }
+        return try? JSONDecoder().decode(Tokens.self, from: data)
+    }
+
+    public func clear() {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+}

--- a/mobile/ios/AgentSOAR/Sources/AgentSOARKit/Config/AgentCoreConfig.swift
+++ b/mobile/ios/AgentSOAR/Sources/AgentSOARKit/Config/AgentCoreConfig.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// Configuration for the AgentSOAR runtime, loaded from `aws-exports.json`.
+///
+/// Mirrors the shape consumed by the React frontend (`frontend/src/lib/auth.ts`)
+/// so the same `aws-exports.json` can drive both clients.
+public struct AgentCoreConfig: Codable, Sendable, Equatable {
+    public let agentRuntimeArn: String
+    public let awsRegion: String
+    public let agentPattern: String
+
+    public let authority: String
+    public let clientId: String
+    public let redirectUri: String
+    public let scope: String
+    public let responseType: String
+
+    public init(
+        agentRuntimeArn: String,
+        awsRegion: String,
+        agentPattern: String,
+        authority: String,
+        clientId: String,
+        redirectUri: String,
+        scope: String = "email openid profile",
+        responseType: String = "code"
+    ) {
+        self.agentRuntimeArn = agentRuntimeArn
+        self.awsRegion = awsRegion
+        self.agentPattern = agentPattern
+        self.authority = authority
+        self.clientId = clientId
+        self.redirectUri = redirectUri
+        self.scope = scope
+        self.responseType = responseType
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case agentRuntimeArn
+        case awsRegion
+        case agentPattern
+        case authority
+        case clientId = "client_id"
+        case redirectUri = "redirect_uri"
+        case scope
+        case responseType = "response_type"
+    }
+
+    /// Decode from a bundled `aws-exports.json` resource.
+    public static func load(from url: URL) throws -> AgentCoreConfig {
+        let data = try Data(contentsOf: url)
+        return try JSONDecoder().decode(AgentCoreConfig.self, from: data)
+    }
+
+    /// Cognito's OAuth authorization endpoint, derived from the OIDC authority.
+    /// Cognito User Pool authorities follow `https://cognito-idp.{region}.amazonaws.com/{poolId}`,
+    /// but the OAuth endpoints live on the user pool domain. The Cognito Hosted UI
+    /// domain is configured separately in `aws-exports.json` via `oauthDomain` when present.
+    public var oauthDomain: URL? {
+        // The frontend reads OAuth endpoints from oidc-client-ts, which auto-discovers them
+        // from the OIDC `.well-known/openid-configuration` document. We do the same — see
+        // CognitoAuthClient.discoverEndpoints().
+        URL(string: authority)
+    }
+}

--- a/mobile/ios/AgentSOAR/Tests/AgentSOARKitTests/AGUIParserTests.swift
+++ b/mobile/ios/AgentSOAR/Tests/AgentSOARKitTests/AGUIParserTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+@testable import AgentSOARKit
+
+final class AGUIParserTests: XCTestCase {
+    private func parse(_ body: String) -> [StreamEvent] {
+        SSEStream.read(body: body, parser: AGUIParser())
+    }
+
+    func testTextMessageContentEmitsTextEvent() {
+        let body = #"data: {"type":"TEXT_MESSAGE_CONTENT","delta":"Hello"}"#
+        XCTAssertEqual(parse(body), [.text("Hello")])
+    }
+
+    func testTextMessageContentMissingDeltaEmitsEmptyText() {
+        let body = #"data: {"type":"TEXT_MESSAGE_CONTENT"}"#
+        XCTAssertEqual(parse(body), [.text("")])
+    }
+
+    func testToolCallStartEmitsToolUseStart() {
+        let body = #"data: {"type":"TOOL_CALL_START","toolCallId":"tool_1","toolCallName":"lookup_finding"}"#
+        XCTAssertEqual(parse(body), [.toolUseStart(toolUseId: "tool_1", name: "lookup_finding")])
+    }
+
+    func testToolCallArgsEmitsToolUseDelta() {
+        let body = #"data: {"type":"TOOL_CALL_ARGS","toolCallId":"tool_1","delta":"{\"id\":\"abc\"}"}"#
+        XCTAssertEqual(parse(body), [.toolUseDelta(toolUseId: "tool_1", input: #"{"id":"abc"}"#)])
+    }
+
+    func testToolCallResultEmitsToolResult() {
+        let body = #"data: {"type":"TOOL_CALL_RESULT","toolCallId":"tool_1","content":"OK"}"#
+        XCTAssertEqual(parse(body), [.toolResult(toolUseId: "tool_1", result: "OK")])
+    }
+
+    func testRunFinishedEmitsResultAndLifecycle() {
+        let body = #"data: {"type":"RUN_FINISHED"}"#
+        XCTAssertEqual(parse(body), [
+            .result(stopReason: "end_turn"),
+            .lifecycle("run_finished"),
+        ])
+    }
+
+    func testRunStartedEmitsLifecycleOnly() {
+        let body = #"data: {"type":"RUN_STARTED"}"#
+        XCTAssertEqual(parse(body), [.lifecycle("run_started")])
+    }
+
+    func testStateSnapshotIsIgnored() {
+        let body = #"data: {"type":"STATE_SNAPSHOT","state":{}}"#
+        XCTAssertTrue(parse(body).isEmpty)
+    }
+
+    func testNonDataLineIsIgnored() {
+        let body = #"event: ping"#
+        XCTAssertTrue(parse(body).isEmpty)
+    }
+
+    func testMalformedJSONIsIgnoredSilently() {
+        let body = #"data: {not json"#
+        XCTAssertTrue(parse(body).isEmpty)
+    }
+
+    func testFullStreamEndToEnd() {
+        let body = """
+        data: {"type":"RUN_STARTED"}
+        data: {"type":"TEXT_MESSAGE_START"}
+        data: {"type":"TEXT_MESSAGE_CONTENT","delta":"Hi "}
+        data: {"type":"TEXT_MESSAGE_CONTENT","delta":"there"}
+        data: {"type":"TOOL_CALL_START","toolCallId":"t1","toolCallName":"lookup"}
+        data: {"type":"TOOL_CALL_ARGS","toolCallId":"t1","delta":"{}"}
+        data: {"type":"TOOL_CALL_RESULT","toolCallId":"t1","content":"done"}
+        data: {"type":"TEXT_MESSAGE_END"}
+        data: {"type":"RUN_FINISHED"}
+        """
+        XCTAssertEqual(parse(body), [
+            .lifecycle("run_started"),
+            .lifecycle("message_start"),
+            .text("Hi "),
+            .text("there"),
+            .toolUseStart(toolUseId: "t1", name: "lookup"),
+            .toolUseDelta(toolUseId: "t1", input: "{}"),
+            .toolResult(toolUseId: "t1", result: "done"),
+            .lifecycle("message_end"),
+            .result(stopReason: "end_turn"),
+            .lifecycle("run_finished"),
+        ])
+    }
+}

--- a/mobile/ios/AgentSOAR/Tests/AgentSOARKitTests/AgentCoreConfigTests.swift
+++ b/mobile/ios/AgentSOAR/Tests/AgentSOARKitTests/AgentCoreConfigTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import AgentSOARKit
+
+final class AgentCoreConfigTests: XCTestCase {
+    func testDecodesAwsExportsShape() throws {
+        let json = #"""
+        {
+          "agentRuntimeArn": "arn:aws:bedrock-agentcore:us-east-1:111:runtime/abc",
+          "awsRegion": "us-east-1",
+          "agentPattern": "agui-strands-agent",
+          "authority": "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_AAA",
+          "client_id": "abc123",
+          "redirect_uri": "agentsoar://auth/callback",
+          "response_type": "code",
+          "scope": "email openid profile"
+        }
+        """#
+        let cfg = try JSONDecoder().decode(AgentCoreConfig.self, from: Data(json.utf8))
+        XCTAssertEqual(cfg.awsRegion, "us-east-1")
+        XCTAssertEqual(cfg.agentPattern, "agui-strands-agent")
+        XCTAssertEqual(cfg.clientId, "abc123")
+        XCTAssertEqual(cfg.redirectUri, "agentsoar://auth/callback")
+    }
+
+    func testDefaultsForOptionalFields() throws {
+        let json = #"""
+        {
+          "agentRuntimeArn": "arn:aws:bedrock-agentcore:us-east-1:111:runtime/abc",
+          "awsRegion": "us-east-1",
+          "agentPattern": "agui-strands-agent",
+          "authority": "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_AAA",
+          "client_id": "abc123",
+          "redirect_uri": "agentsoar://auth/callback"
+        }
+        """#
+        // scope and response_type are required by the Codable above to be present;
+        // this test documents that the example config must include them.
+        XCTAssertThrowsError(try JSONDecoder().decode(AgentCoreConfig.self, from: Data(json.utf8)))
+    }
+}

--- a/mobile/ios/AgentSOAR/Tests/AgentSOARKitTests/PKCETests.swift
+++ b/mobile/ios/AgentSOAR/Tests/AgentSOARKitTests/PKCETests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import AgentSOARKit
+
+final class PKCETests: XCTestCase {
+    func testPairsAreUniqueAcrossInvocations() {
+        let a = PKCE.generate()
+        let b = PKCE.generate()
+        XCTAssertNotEqual(a.verifier, b.verifier)
+        XCTAssertNotEqual(a.challenge, b.challenge)
+    }
+
+    func testVerifierUsesURLSafeAlphabet() {
+        let p = PKCE.generate()
+        let allowed = CharacterSet(charactersIn:
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_")
+        XCTAssertNil(p.verifier.rangeOfCharacter(from: allowed.inverted))
+        XCTAssertNil(p.challenge.rangeOfCharacter(from: allowed.inverted))
+    }
+
+    func testMethodIsS256() {
+        XCTAssertEqual(PKCE.generate().method, "S256")
+    }
+}

--- a/mobile/ios/README.md
+++ b/mobile/ios/README.md
@@ -1,0 +1,143 @@
+# AgentSOAR iOS App
+
+Native SwiftUI client for the AgentSOAR Bedrock AgentCore runtime. Talks to the
+same `bedrock-agentcore.{region}.amazonaws.com/runtimes/{arn}/invocations`
+endpoint as the React frontend, streams AG-UI events over SSE, and renders text
+deltas + tool calls as they arrive.
+
+## Layout
+
+```
+mobile/ios/AgentSOAR/
+├── Package.swift                      Swift Package: AgentSOARKit + tests
+├── Sources/
+│   ├── AgentSOARKit/                  Reusable SDK (auth, streaming, parser)
+│   │   ├── AgentCore/
+│   │   │   ├── AgentCoreClient.swift  POST /invocations + SSE streaming
+│   │   │   ├── AGUIParser.swift       Port of frontend agui parser
+│   │   │   ├── SSEStream.swift        URLSession.AsyncBytes → events
+│   │   │   └── StreamEvent.swift
+│   │   ├── Auth/
+│   │   │   ├── CognitoAuthClient.swift  PKCE OAuth via ASWebAuthenticationSession
+│   │   │   ├── PKCE.swift               RFC 7636 code verifier/challenge
+│   │   │   └── TokenStore.swift         Keychain-backed token persistence
+│   │   └── Config/
+│   │       └── AgentCoreConfig.swift  Decodes aws-exports.json
+│   └── AgentSOARApp/                  SwiftUI app sources (drag into Xcode)
+│       ├── App/AgentSOARApp.swift     @main entry + RootView
+│       ├── Login/LoginView.swift      Sign-in button → ASWebAuthenticationSession
+│       ├── Chat/ChatView.swift        Streaming transcript UI
+│       ├── Chat/ChatViewModel.swift
+│       ├── Chat/ChatMessage.swift
+│       └── Resources/
+│           ├── Info.plist             URL scheme: agentsoar://
+│           └── aws-exports.example.json
+└── Tests/AgentSOARKitTests/           XCTest suites
+```
+
+## Building the iOS app
+
+The Swift Package compiles the SDK + tests on macOS / Linux. The full app needs
+Xcode (SwiftUI, Keychain, ASWebAuthenticationSession).
+
+### 1. Create the Xcode project
+
+```bash
+open -a Xcode mobile/ios/AgentSOAR/Package.swift   # opens the package
+```
+
+Then in Xcode:
+
+1. **File → New → Project → iOS → App**, name `AgentSOAR`, interface SwiftUI,
+   minimum deployment iOS 16.
+2. Save it inside `mobile/ios/AgentSOAR/` (sibling to `Package.swift`).
+3. Delete the default `ContentView.swift` and `*App.swift` Xcode generated.
+4. Drag `Sources/AgentSOARApp/` into the project (Add to target: `AgentSOAR`).
+5. Drag `Sources/AgentSOARApp/Resources/Info.plist` into the project, then in
+   Build Settings set **Info.plist File** to that path.
+6. **Add Package Dependency → Add Local…** and pick `mobile/ios/AgentSOAR`
+   (the `Package.swift`). Add the `AgentSOARKit` library to the app target.
+
+### 2. Wire up Cognito
+
+Copy `Sources/AgentSOARApp/Resources/aws-exports.example.json` to
+`aws-exports.json`, fill in real values from the deployed CDK stack, and add it
+to the app bundle (drag into Xcode → Add to target).
+
+The mobile redirect URI must be registered as an allowed callback on the
+Cognito User Pool client. The example uses a custom scheme:
+
+```
+agentsoar://auth/callback
+```
+
+Add it via the AWS console or CDK:
+
+```bash
+aws cognito-idp update-user-pool-client \
+  --user-pool-id us-east-1_xxx \
+  --client-id xxx \
+  --callback-urls "https://app.example.com/" "agentsoar://auth/callback" \
+  --allowed-o-auth-flows code \
+  --allowed-o-auth-scopes openid email profile \
+  --allowed-o-auth-flows-user-pool-client \
+  --profile blanxlait-security
+```
+
+### 3. Run
+
+Plug in a device or pick a simulator and **⌘R**. First launch shows the login
+screen; after Cognito sign-in tokens are stored in the iOS Keychain and the
+chat view streams from the AG-UI runtime.
+
+## Running tests
+
+```bash
+cd mobile/ios/AgentSOAR
+swift test
+```
+
+The tests cover the AG-UI parser (event mapping, malformed inputs, full
+end-to-end stream), PKCE generation, and `AgentCoreConfig` decoding. They run
+on macOS or Linux without simulators.
+
+## Wire format
+
+Identical to the web client (`frontend/src/lib/agentcore-client/client.ts`):
+
+```http
+POST https://bedrock-agentcore.{region}.amazonaws.com/runtimes/{escapedArn}/invocations?qualifier=DEFAULT
+Authorization: Bearer {cognito_access_token}
+Content-Type: application/json
+X-Amzn-Trace-Id: 1-{epochHex}-{uuid}
+X-Amzn-Bedrock-AgentCore-Runtime-Session-Id: {sessionUuid}
+
+{
+  "threadId":   "{sessionUuid}",
+  "runId":      "{uuid}",
+  "messages":   [{"id": "{uuid}", "role": "user", "content": "..."}],
+  "state":      {},
+  "tools":      [],
+  "context":    [],
+  "forwardedProps": {}
+}
+```
+
+Responses are SSE: each `data: <json>` line is fed through `AGUIParser` and
+emitted as `StreamEvent`s.
+
+## Security notes
+
+- Access tokens live in the iOS Keychain (`kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`).
+- User identity is extracted server-side from the JWT — never sent in the
+  payload, mirroring the web client.
+- PKCE S256 is mandatory for the auth code flow.
+- `ASWebAuthenticationSession` is preferred over a custom WKWebView so federated
+  identity providers and Cognito SSO cookies work transparently.
+
+## Roadmap
+
+- Push notifications for incoming security findings
+- Background refresh for long-running runs
+- Per-finding deep links (`agentsoar://findings/{id}`)
+- Add Strands / LangGraph parsers for non-AG-UI patterns


### PR DESCRIPTION
## Summary

- New SwiftUI iOS app at `mobile/ios/AgentSOAR/` that talks to the same Bedrock AgentCore runtime as the React frontend.
- Reusable Swift Package `AgentSOARKit` (auth, streaming, AG-UI parser) so future macOS / Watch / Shortcuts targets can share the SDK.
- Cognito Authorization Code + PKCE via `ASWebAuthenticationSession`; tokens persisted in the iOS Keychain (`kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`); silent refresh on expiry.
- `ChatView` streams text deltas and renders tool calls inline, mirroring the React `ChatInterface`.
- XCTest coverage for the AG-UI parser (event mapping, malformed JSON, full end-to-end stream), PKCE generation, and `AgentCoreConfig` decoding.
- Blog post `blog/04-ios-mobile-app.md` documenting the build per the project rule.

## Wire format parity

The Swift `AgentCoreClient` is a direct port of `frontend/src/lib/agentcore-client/client.ts`:
- `POST https://bedrock-agentcore.{region}.amazonaws.com/runtimes/{escapedArn}/invocations?qualifier=DEFAULT`
- `Authorization: Bearer {cognito_access_token}` (user identity is extracted server-side from the JWT — never sent in the body, same comment carried over from the web client).
- AG-UI payload shape (`threadId`, `runId`, `messages`, `state`, `tools`, `context`, `forwardedProps`).
- SSE response parsed by the same event-type switch as `parsers/agui.ts`.

## File map

```
mobile/ios/AgentSOAR/
├── Package.swift                      AgentSOARKit + tests (no UI deps)
├── Sources/
│   ├── AgentSOARKit/
│   │   ├── AgentCore/{Client,AGUIParser,SSEStream,StreamEvent}.swift
│   │   ├── Auth/{CognitoAuthClient,PKCE,TokenStore}.swift
│   │   └── Config/AgentCoreConfig.swift
│   └── AgentSOARApp/                  SwiftUI app sources (Xcode-only)
│       ├── App/AgentSOARApp.swift     @main + RootView
│       ├── Login/LoginView.swift
│       ├── Chat/{ChatView,ChatViewModel,ChatMessage}.swift
│       └── Resources/{Info.plist,aws-exports.example.json}
└── Tests/AgentSOARKitTests/{AGUIParser,PKCE,AgentCoreConfig}Tests.swift
```

## Test plan

- [ ] `cd mobile/ios/AgentSOAR && swift test` — unit tests pass on macOS / Linux.
- [ ] Open `Package.swift` in Xcode 15+; SDK builds for iOS 16 simulator with no warnings.
- [ ] Scaffold an iOS App target per `mobile/ios/README.md`, drop in `aws-exports.json`, and verify:
  - [ ] Sign-in launches `ASWebAuthenticationSession`, returns to `agentsoar://auth/callback`, stores tokens in Keychain.
  - [ ] Chat view streams text deltas with the cursor `▍` while running.
  - [ ] Tool calls render inline (wrench icon, args preview, green check on result).
  - [ ] "New" toolbar button starts a fresh session id; "Sign out" clears Keychain and returns to login.
- [ ] Add `agentsoar://auth/callback` to the Cognito User Pool client callback URLs (one-time manual step documented in the README).

## Out of scope (follow-ups)

- Push notifications wired into the GuardDuty pipeline.
- CDK property to register the iOS callback URL automatically.
- Build script that pulls `aws-exports.json` from the deployed Amplify origin.
- macOS Catalyst target (SDK already has no UIKit deps).

https://claude.ai/code/session_01Hr1ihc8crSfgdCf396to4M

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hr1ihc8crSfgdCf396to4M)_