### PR TITLE
fix(ios): address Copilot review feedback from #39

### DIFF
--- a/blog/04-ios-mobile-app.md
+++ b/blog/04-ios-mobile-app.md
@@ -218,8 +218,8 @@ open Package.swift   # or follow mobile/ios/README.md to scaffold the Xcode app
 swift test
 ```
 
-The unit tests run on macOS or Linux without simulators. The full app needs
-Xcode 15 and an iOS 16+ device.
+The unit tests run on macOS without simulators. The full app needs Xcode 15
+and an iOS 16+ device.
 
 Next up: wiring push notifications into the GuardDuty pipeline so the agent
 can wake your phone.

--- a/mobile/ios/AgentSOAR/Package.swift
+++ b/mobile/ios/AgentSOAR/Package.swift
@@ -4,6 +4,9 @@
 // Builds:
 //   • AgentSOARKit — embeddable library (auth, streaming, AG-UI parsing)
 //   • AgentSOARKitTests — unit tests for the parser and SSE reader
+//
+// Apple-only: depends on CryptoKit and Security. `swift test` runs on macOS;
+// the full app requires Xcode + iOS 16.
 
 import PackageDescription
 

--- a/mobile/ios/AgentSOAR/Sources/AgentSOARApp/Chat/ChatView.swift
+++ b/mobile/ios/AgentSOAR/Sources/AgentSOARApp/Chat/ChatView.swift
@@ -28,9 +28,15 @@ public struct ChatView: View {
                     Button("Sign out", action: onSignOut)
                 }
             }
-            .alert("Error", isPresented: .constant(vm.error != nil), actions: {
-                Button("OK") { vm.error = nil }
-            }, message: { Text(vm.error ?? "") })
+            .alert(
+                "Error",
+                isPresented: Binding(
+                    get: { vm.error != nil },
+                    set: { isPresented in if !isPresented { vm.error = nil } }
+                ),
+                actions: { Button("OK") { vm.error = nil } },
+                message: { Text(vm.error ?? "") }
+            )
         }
     }
 
@@ -59,12 +65,16 @@ public struct ChatView: View {
                 .lineLimit(1...5)
                 .disabled(vm.isLoading)
             Button {
-                Task { await vm.send() }
+                if vm.isLoading {
+                    vm.cancel()
+                } else {
+                    vm.send()
+                }
             } label: {
                 Image(systemName: vm.isLoading ? "stop.circle.fill" : "arrow.up.circle.fill")
                     .font(.system(size: 28))
             }
-            .disabled(vm.draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || vm.isLoading)
+            .disabled(!vm.isLoading && vm.draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
         }
         .padding(.horizontal)
         .padding(.vertical, 8)

--- a/mobile/ios/AgentSOAR/Sources/AgentSOARApp/Chat/ChatViewModel.swift
+++ b/mobile/ios/AgentSOAR/Sources/AgentSOARApp/Chat/ChatViewModel.swift
@@ -11,6 +11,7 @@ public final class ChatViewModel: ObservableObject {
     private let client: AgentCoreClient
     private let auth: CognitoAuthClient
     private var sessionId: String
+    private var sendTask: Task<Void, Never>?
 
     public init(client: AgentCoreClient, auth: CognitoAuthClient) {
         self.client = client
@@ -19,46 +20,61 @@ public final class ChatViewModel: ObservableObject {
     }
 
     public func resetSession() {
+        sendTask?.cancel()
+        sendTask = nil
         sessionId = client.generateSessionId()
         messages.removeAll()
     }
 
-    public func send() async {
+    /// Cancels the in-flight stream, if any. Safe to call when idle.
+    public func cancel() {
+        sendTask?.cancel()
+    }
+
+    public func send() {
         let text = draft.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !text.isEmpty, !isLoading else { return }
         draft = ""
         error = nil
 
         messages.append(ChatMessage(role: .user, text: text))
-        var assistant = ChatMessage(role: .assistant, isStreaming: true)
+        let assistant = ChatMessage(role: .assistant, isStreaming: true)
         messages.append(assistant)
         let assistantId = assistant.id
         isLoading = true
-        defer { isLoading = false }
 
-        do {
-            guard let token = try await auth.validAccessToken() else {
-                error = "Sign in required."
-                markFinished(id: assistantId)
-                return
+        sendTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer {
+                self.markFinished(id: assistantId)
+                self.isLoading = false
+                self.sendTask = nil
             }
+            do {
+                guard let token = try await self.auth.validAccessToken() else {
+                    self.error = "Sign in required."
+                    return
+                }
 
-            let stream = try await client.invoke(
-                query: text,
-                sessionId: sessionId,
-                accessToken: token
-            )
+                let stream = try await self.client.invoke(
+                    query: text,
+                    sessionId: self.sessionId,
+                    accessToken: token
+                )
 
-            for try await event in stream {
-                apply(event: event, to: assistantId, snapshot: &assistant)
+                for try await event in stream {
+                    if Task.isCancelled { break }
+                    self.apply(event: event, to: assistantId)
+                }
+            } catch is CancellationError {
+                // user cancelled — keep partial message, clear streaming state
+            } catch {
+                self.error = error.localizedDescription
             }
-        } catch {
-            self.error = error.localizedDescription
         }
-        markFinished(id: assistantId)
     }
 
-    private func apply(event: StreamEvent, to id: UUID, snapshot: inout ChatMessage) {
+    private func apply(event: StreamEvent, to id: UUID) {
         guard let idx = messages.firstIndex(where: { $0.id == id }) else { return }
         switch event {
         case let .text(content):

--- a/mobile/ios/AgentSOAR/Sources/AgentSOARKit/AgentCore/AgentCoreClient.swift
+++ b/mobile/ios/AgentSOAR/Sources/AgentSOARKit/AgentCore/AgentCoreClient.swift
@@ -92,10 +92,11 @@ public final class AgentCoreClient: Sendable {
         guard let http = response as? HTTPURLResponse else { throw AgentCoreError.invalidResponse }
 
         guard (200..<300).contains(http.statusCode) else {
-            var bodyText = ""
+            var bodyData = Data()
             for try await byte in bytes {
-                bodyText.append(Character(UnicodeScalar(byte)))
+                bodyData.append(byte)
             }
+            let bodyText = String(decoding: bodyData, as: UTF8.self)
             throw AgentCoreError.http(status: http.statusCode, body: bodyText)
         }
 

--- a/mobile/ios/AgentSOAR/Sources/AgentSOARKit/AgentCore/SSEStream.swift
+++ b/mobile/ios/AgentSOAR/Sources/AgentSOARKit/AgentCore/SSEStream.swift
@@ -14,23 +14,26 @@ public enum SSEStream {
         AsyncThrowingStream { continuation in
             let task = Task {
                 do {
-                    var buffer = ""
+                    // Buffer raw bytes and decode each line as UTF-8 — building
+                    // the line out of `Character(UnicodeScalar(byte))` would
+                    // mangle multi-byte scalars.
+                    var buffer = Data()
+                    let newline = UInt8(ascii: "\n")
                     for try await byte in bytes {
-                        let scalar = UnicodeScalar(byte)
-                        let char = Character(scalar)
-                        if char == "\n" {
-                            let line = buffer
-                            buffer = ""
+                        if byte == newline {
+                            let line = String(decoding: buffer, as: UTF8.self)
+                            buffer.removeAll(keepingCapacity: true)
                             guard !line.trimmingCharacters(in: .whitespaces).isEmpty else { continue }
                             parser.parse(line: line) { event in
                                 continuation.yield(event)
                             }
                         } else {
-                            buffer.append(char)
+                            buffer.append(byte)
                         }
                     }
-                    if !buffer.trimmingCharacters(in: .whitespaces).isEmpty {
-                        parser.parse(line: buffer) { event in
+                    let trailing = String(decoding: buffer, as: UTF8.self)
+                    if !trailing.trimmingCharacters(in: .whitespaces).isEmpty {
+                        parser.parse(line: trailing) { event in
                             continuation.yield(event)
                         }
                     }

--- a/mobile/ios/AgentSOAR/Sources/AgentSOARKit/Auth/CognitoAuthClient.swift
+++ b/mobile/ios/AgentSOAR/Sources/AgentSOARKit/Auth/CognitoAuthClient.swift
@@ -33,6 +33,8 @@ private struct TokenResponse: Decodable {
 public enum AuthError: Error, LocalizedError {
     case userCancelled
     case missingCode
+    case stateMismatch
+    case invalidAuthority
     case discoveryFailed
     case tokenExchangeFailed(String)
     case notAvailable
@@ -41,6 +43,8 @@ public enum AuthError: Error, LocalizedError {
         switch self {
         case .userCancelled: return "Sign-in cancelled."
         case .missingCode: return "No authorization code returned by Cognito."
+        case .stateMismatch: return "OAuth state mismatch — possible CSRF."
+        case .invalidAuthority: return "Authority URL is invalid."
         case .discoveryFailed: return "Failed to load OIDC discovery document."
         case let .tokenExchangeFailed(detail): return "Token exchange failed: \(detail)"
         case .notAvailable: return "Web auth is unavailable on this platform."
@@ -57,6 +61,13 @@ public final class CognitoAuthClient: NSObject {
     private let config: AgentCoreConfig
     private let store: KeychainTokenStore
     private let session: URLSession
+
+    #if canImport(AuthenticationServices)
+    /// Strong reference to the in-flight web auth session. `ASWebAuthenticationSession`
+    /// is cancelled if it gets deallocated mid-flow, so we hold it here until the
+    /// completion handler fires.
+    @MainActor private var currentAuthSession: ASWebAuthenticationSession?
+    #endif
 
     public init(
         config: AgentCoreConfig,
@@ -92,9 +103,11 @@ public final class CognitoAuthClient: NSObject {
     public func signIn(presentationAnchor: ASPresentationAnchor) async throws -> KeychainTokenStore.Tokens {
         let discovery = try await discoverEndpoints()
         let pkce = PKCE.generate()
-        let state = UUID().uuidString
+        let expectedState = UUID().uuidString
 
-        var components = URLComponents(url: discovery.authorizationEndpoint, resolvingAgainstBaseURL: false)!
+        guard var components = URLComponents(url: discovery.authorizationEndpoint, resolvingAgainstBaseURL: false) else {
+            throw AuthError.discoveryFailed
+        }
         components.queryItems = [
             URLQueryItem(name: "client_id", value: config.clientId),
             URLQueryItem(name: "response_type", value: config.responseType),
@@ -102,7 +115,7 @@ public final class CognitoAuthClient: NSObject {
             URLQueryItem(name: "redirect_uri", value: config.redirectUri),
             URLQueryItem(name: "code_challenge", value: pkce.challenge),
             URLQueryItem(name: "code_challenge_method", value: pkce.method),
-            URLQueryItem(name: "state", value: state),
+            URLQueryItem(name: "state", value: expectedState),
         ]
         guard let authURL = components.url else { throw AuthError.discoveryFailed }
 
@@ -112,7 +125,8 @@ public final class CognitoAuthClient: NSObject {
             let session = ASWebAuthenticationSession(
                 url: authURL,
                 callbackURLScheme: callbackScheme
-            ) { url, error in
+            ) { [weak self] url, error in
+                Task { @MainActor [weak self] in self?.currentAuthSession = nil }
                 if let error {
                     if (error as NSError).code == ASWebAuthenticationSessionError.canceledLogin.rawValue {
                         cont.resume(throwing: AuthError.userCancelled)
@@ -126,12 +140,17 @@ public final class CognitoAuthClient: NSObject {
             }
             session.presentationContextProvider = AnchorProvider(anchor: presentationAnchor)
             session.prefersEphemeralWebBrowserSession = false
+            currentAuthSession = session
             session.start()
         }
 
-        guard let code = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false)?
-                .queryItems?.first(where: { $0.name == "code" })?.value
-        else { throw AuthError.missingCode }
+        let queryItems = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false)?.queryItems
+        guard let returnedState = queryItems?.first(where: { $0.name == "state" })?.value,
+              returnedState == expectedState
+        else { throw AuthError.stateMismatch }
+        guard let code = queryItems?.first(where: { $0.name == "code" })?.value else {
+            throw AuthError.missingCode
+        }
 
         return try await exchangeCode(
             code: code,
@@ -150,7 +169,9 @@ public final class CognitoAuthClient: NSObject {
     private func discoverEndpoints() async throws -> OIDCDiscovery {
         // Cognito User Pool authorities serve OIDC discovery at
         // `{authority}/.well-known/openid-configuration`.
-        let discoveryURL = URL(string: "\(config.authority)/.well-known/openid-configuration")!
+        guard let authorityURL = URL(string: config.authority),
+              let discoveryURL = URL(string: "\(authorityURL.absoluteString)/.well-known/openid-configuration")
+        else { throw AuthError.invalidAuthority }
         let (data, response) = try await session.data(from: discoveryURL)
         guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
             throw AuthError.discoveryFailed

--- a/mobile/ios/AgentSOAR/Sources/AgentSOARKit/Auth/PKCE.swift
+++ b/mobile/ios/AgentSOAR/Sources/AgentSOARKit/Auth/PKCE.swift
@@ -1,5 +1,6 @@
 import CryptoKit
 import Foundation
+import Security
 
 /// Generates PKCE code verifier / challenge pairs per RFC 7636.
 public enum PKCE {
@@ -17,7 +18,10 @@ public enum PKCE {
 
     private static func randomURLSafeString(byteCount: Int) -> String {
         var bytes = [UInt8](repeating: 0, count: byteCount)
-        _ = SecRandomCopyBytes(kSecRandomDefault, byteCount, &bytes)
+        // Falling back to a predictable verifier would silently break PKCE's
+        // CSRF protections; trap on failure instead.
+        let status = SecRandomCopyBytes(kSecRandomDefault, byteCount, &bytes)
+        precondition(status == errSecSuccess, "SecRandomCopyBytes failed: \(status)")
         return Data(bytes).base64URLEncodedString()
     }
 

--- a/mobile/ios/AgentSOAR/Sources/AgentSOARKit/Config/AgentCoreConfig.swift
+++ b/mobile/ios/AgentSOAR/Sources/AgentSOARKit/Config/AgentCoreConfig.swift
@@ -51,15 +51,4 @@ public struct AgentCoreConfig: Codable, Sendable, Equatable {
         let data = try Data(contentsOf: url)
         return try JSONDecoder().decode(AgentCoreConfig.self, from: data)
     }
-
-    /// Cognito's OAuth authorization endpoint, derived from the OIDC authority.
-    /// Cognito User Pool authorities follow `https://cognito-idp.{region}.amazonaws.com/{poolId}`,
-    /// but the OAuth endpoints live on the user pool domain. The Cognito Hosted UI
-    /// domain is configured separately in `aws-exports.json` via `oauthDomain` when present.
-    public var oauthDomain: URL? {
-        // The frontend reads OAuth endpoints from oidc-client-ts, which auto-discovers them
-        // from the OIDC `.well-known/openid-configuration` document. We do the same — see
-        // CognitoAuthClient.discoverEndpoints().
-        URL(string: authority)
-    }
 }

--- a/mobile/ios/README.md
+++ b/mobile/ios/README.md
@@ -37,8 +37,9 @@ mobile/ios/AgentSOAR/
 
 ## Building the iOS app
 
-The Swift Package compiles the SDK + tests on macOS / Linux. The full app needs
-Xcode (SwiftUI, Keychain, ASWebAuthenticationSession).
+The Swift Package compiles the SDK + tests on macOS (the SDK depends on
+`CryptoKit` and `Security`, which are Apple-only). The full app needs Xcode
+(SwiftUI, Keychain, ASWebAuthenticationSession).
 
 ### 1. Create the Xcode project
 
@@ -99,7 +100,7 @@ swift test
 
 The tests cover the AG-UI parser (event mapping, malformed inputs, full
 end-to-end stream), PKCE generation, and `AgentCoreConfig` decoding. They run
-on macOS or Linux without simulators.
+on macOS without simulators.
 
 ## Wire format
 


### PR DESCRIPTION
Follow-up to #39. Copilot's automated review left 13 comments after the merge — this PR addresses every one of them.

## Compile / correctness fixes

- **`PKCE.swift` — `import Security`**: previously called `SecRandomCopyBytes` / `kSecRandomDefault` without importing `Security`, so the file wouldn't compile on Apple platforms. Also discarded the `OSStatus`, which would have silently produced an all-zero verifier on failure. Now traps via `precondition(status == errSecSuccess)`.
- **SSE / error body UTF-8**: `SSEStream.read(bytes:)` and the error-body branch of `AgentCoreClient.invoke` were building strings via `Character(UnicodeScalar(byte))`, which splits multi-byte UTF-8 scalars. Now buffers raw `UInt8` bytes in `Data` and decodes each line with `String(decoding: data, as: UTF8.self)` — same shape as the web client's `TextDecoder`.
- **`discoverEndpoints` force-unwrap**: a malformed `authority` would crash the app. Now constructs the URL safely and throws a new `AuthError.invalidAuthority`.

## Security fixes

- **OAuth `state` validation**: the parameter was generated and sent but never compared on the callback. Now reads `state` from the redirect URL and throws `AuthError.stateMismatch` if it doesn't match the value we generated, restoring CSRF / auth-code-mixup protection.
- **Retain `ASWebAuthenticationSession`**: the session was a local var inside `withCheckedThrowingContinuation`, so ARC could deallocate it before the user finished signing in (the system cancels the session in that case). Now stored on `CognitoAuthClient` as `@MainActor private var currentAuthSession` and cleared in the completion handler.

## UI / model fixes

- **Send button cancellation**: the button swapped to a stop icon while `isLoading`, but was *also* disabled — users could never cancel. Stores the in-flight `Task` in `ChatViewModel.sendTask` and exposes `cancel()`; the button now stays enabled while loading and actually cancels the stream. `CancellationError` is swallowed cleanly so the partial assistant message is preserved.
- **Unused `inout snapshot`**: `apply(event:to:snapshot:)` took an `inout` parameter that was never read or written. Removed.
- **Alert binding**: `.alert(isPresented: .constant(...))` prevented SwiftUI from clearing the binding on dismissal. Replaced with a real `Binding<Bool>` whose setter clears `vm.error`.

## API / docs cleanup

- **`oauthDomain` removed**: the property's docstring promised a separately decoded `oauthDomain` field in `aws-exports.json`, but the struct didn't decode any such field — it just returned `URL(string: authority)`. The accessor is unused; deleted.
- **Docs no longer claim Linux test support**: `CryptoKit` and `Security` are Apple-only, so `swift test` only runs on macOS. Updated `mobile/ios/README.md`, `blog/04-ios-mobile-app.md`, and the `Package.swift` header to say so. (Adding `swift-crypto` for Linux parity is doable but out of scope here.)

## Test plan

- [x] `git diff main..` confirms only `mobile/ios/**`, `blog/04-ios-mobile-app.md` touched.
- [ ] `cd mobile/ios/AgentSOAR && swift test` on macOS — existing parser/PKCE/config suites pass.
- [ ] On a real device:
  - [ ] First sign-in flow completes without the auth session being dismissed early.
  - [ ] Tampering the `state` query param in a synthetic callback URL throws `stateMismatch`.
  - [ ] Tapping the stop icon during a stream cancels and leaves the partial reply in place.
  - [ ] Error alert dismisses cleanly via the X / outside tap.

https://claude.ai/code/session_01Hr1ihc8crSfgdCf396to4M

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hr1ihc8crSfgdCf396to4M)_